### PR TITLE
Correct date (and changed its format) for the first release

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,4 @@
-Revision history for Perl extension Text::VisualWidth::PP
+Revision history for Perl module Text::VisualWidth::PP
 
 {{$NEXT}}
 
@@ -14,5 +14,7 @@ Revision history for Perl extension Text::VisualWidth::PP
 
     - Added $Text::VisualWidth::PP::EastAsian
 
-0.01    Mon Jun 14 00:09:36 2010
-        - original version
+0.01 2010-06-13
+
+    - original version
+


### PR DESCRIPTION
The date wasn't set right for the first release - I guess it was the date
you created the dist locally? Changed it to the date that BackPAN says it was first released, and changed the format of that date to ISO 8601 date format.
