### PR TITLE
Fix combined character test to run with perl < 5.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: test
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        perl: [ '5.34', '5.28', '5.18', '5.16', '5.14', '5.12', '5.10', '5.8' ]
+    name: Perl ${{ matrix.perl }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl }}
+      - run: perl -V
+      - run: cpanm --installdeps --notest .
+      - run: prove -lvr t

--- a/META.json
+++ b/META.json
@@ -1,5 +1,5 @@
 {
-   "abstract" : "trimming text by the number of the column s of terminals and mobile phones.",
+   "abstract" : "trimming text by the number of the columns of terminals and mobile phones.",
    "author" : [
       "Tokuhiro Matsuno <tokuhirom AAJKLFJEF GMAIL COM>"
    ],

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NAME
 
-Text::VisualWidth::PP - trimming text by the number of the column s of terminals and mobile phones.
+Text::VisualWidth::PP - trimming text by the number of the columns of terminals and mobile phones.
 
 # SYNOPSIS
 

--- a/README.mkdn
+++ b/README.mkdn
@@ -1,6 +1,6 @@
 # NAME
 
-Text::VisualWidth::PP - trimming text by the number of the column s of terminals and mobile phones.
+Text::VisualWidth::PP - trimming text by the number of the columns of terminals and mobile phones.
 
 # SYNOPSIS
 

--- a/lib/Text/VisualWidth/PP.pm
+++ b/lib/Text/VisualWidth/PP.pm
@@ -92,7 +92,7 @@ __END__
 
 =head1 NAME
 
-Text::VisualWidth::PP - trimming text by the number of the column s of terminals and mobile phones.
+Text::VisualWidth::PP - trimming text by the number of the columns of terminals and mobile phones.
 
 =head1 SYNOPSIS
 

--- a/t/06_combined.t
+++ b/t/06_combined.t
@@ -1,82 +1,55 @@
 use strict;
 use warnings;
 use utf8;
-use charnames qw(:full);
 use Test::More;
 BEGIN { use_ok('Text::VisualWidth::PP') };
 
 binmode STDOUT, ":encoding(utf8)";
+binmode STDERR, ":encoding(utf8)";
 
 ok( Text::VisualWidth::PP::width("123abcﾊﾟﾋﾟﾌﾟパピプ") == 18, 'Normal width');
-is( Text::VisualWidth::PP::trim("123ﾊﾟﾋﾟﾌﾟパピプ",7), '123ﾊﾟﾋﾟ', 'Halfwidth Kana trim');
-is( Text::VisualWidth::PP::trim("123ﾊﾟﾋﾟﾌﾟパピプ",8), '123ﾊﾟﾋﾟ', 'Halfwidth Kana trim');
-is( Text::VisualWidth::PP::trim("123ﾊﾟﾋﾟﾌﾟパピプ",9), '123ﾊﾟﾋﾟﾌﾟ', 'Halfwidth Kana trim');
-
-sub evalcharname {
-    eval sprintf q("\\N{%s}"), $_[0];
+is( Text::VisualWidth::PP::trim("123ﾊﾟﾋﾟﾌﾟパピプ",7), '123ﾊﾟﾋﾟ', 'Halfwidth Kana trim 1');
+# \X behave different in perl < 5.12
+if ($] < 5.011) {
+    is( Text::VisualWidth::PP::trim("123ﾊﾟﾋﾟﾌﾟパピプ",8), '123ﾊﾟﾋﾟﾌ', 'Halfwidth Kana trim 2-1');
+} else {
+    is( Text::VisualWidth::PP::trim("123ﾊﾟﾋﾟﾌﾟパピプ",8), '123ﾊﾟﾋﾟ', 'Halfwidth Kana trim 2-2');
 }
+is( Text::VisualWidth::PP::trim("123ﾊﾟﾋﾟﾌﾟパピプ",9), '123ﾊﾟﾋﾟﾌﾟ', 'Halfwidth Kana trim 3');
 
-SKIP: {
-
-evalcharname("HIRAGANA LETTER A")
-    or skip "Unicode charname is not supported.";
-
-sub kana {
-    my $X_KANA = shift;
-    map  { @$_ }
-    grep { defined $_->[1] }
-    map  { [ $_->[0], evalcharname($_->[1]) ] }
-    map  {					# UNICODE NAME
-	( [ $_,    "$X_KANA LETTER $_" ],
-	  [ "x$_", "$X_KANA LETTER SMALL $_" ] )
-    }
-    map  {					# KA KI KU KE KO SA ...
-	my $c = $_;
-	map { "$c$_" } qw(A I U E O);
-    }
-    'KSTNHMYRW GZDBP' =~ /\A|\w/g;
-}
-my %k = kana "KATAKANA";
-my %h = kana "HIRAGANA";
-my %m = do {
-    map  { @$_ }
-    grep { defined $_->[1] }
-    map  { [ $_->[0], evalcharname($_->[1]) ] }
-    ( [ 'CT' => "COMBINING KATAKANA-HIRAGANA VOICED SOUND MARK" ],
-      [ 'CM' => "COMBINING KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK" ],
-      [ 'T'  => "KATAKANA-HIRAGANA VOICED SOUND MARK" ],
-      [ 'M'  => "KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK" ],
+my %m = (
+    'CT' => "\x{3099}", # COMBINING KATAKANA-HIRAGANA VOICED SOUND MARK
+    'CM' => "\x{309a}", # COMBINING KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
+    'T'  => "\x{309b}", # KATAKANA-HIRAGANA VOICED SOUND MARK
+    'M'  => "\x{309c}", # KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
     );
-};
 
 # ハ゜ヒ゜フ゜
-my $c_papipu = "$k{HA}$m{CM}$k{HI}$m{CM}$k{HU}$m{CM}";
+my $c_papipu = "ハ$m{CM}ヒ$m{CM}フ$m{CM}";
 ok( Text::VisualWidth::PP::width("123abc${c_papipu}ﾊﾟﾋﾟﾌﾟ") == 18, 'Combined width');
 is( Text::VisualWidth::PP::trim("123${c_papipu}ﾊﾟﾋﾟﾌﾟ",11),
     "123${c_papipu}ﾊﾟ",
-    'Combined trim');
+    'Combined trim 1');
 is( Text::VisualWidth::PP::trim("123${c_papipu}ﾊﾟﾋﾟﾌﾟ",8),
     "123\x{30cf}\x{309a}\x{30d2}\x{309a}",
-    'Combined trim');
+    'Combined trim 2');
 
 # マ゛ミ゛
-my $c_mami = "$k{MA}$m{CT}$k{MI}$m{CT}";
+my $c_mami = "マ$m{CT}ミ$m{CT}";
 is( Text::VisualWidth::PP::trim("${c_mami}",4),
     "${c_mami}",
-    'Combined trim');
+    'Combined trim 3');
 is( Text::VisualWidth::PP::trim("${c_mami}",3),
-    "$k{MA}$m{CT}",
-    'Combined trim');
+    "マ$m{CT}",
+    'Combined trim 4');
 is( Text::VisualWidth::PP::trim("${c_mami}",2),
-    "$k{MA}$m{CT}",
-    'Combined trim');
-
-}
+    "マ$m{CT}",
+    'Combined trim 5');
 
 # Vietnamese
 ok( Text::VisualWidth::PP::width("Mọi người") == 9, 'VI width');
-is( Text::VisualWidth::PP::trim("Mọi người",2), "Mọ", 'VI trim');
-is( Text::VisualWidth::PP::trim("Mọi người",8), "Mọi ngườ", 'VI trim');
+is( Text::VisualWidth::PP::trim("Mọi người",2), "Mọ", 'VI trim 1');
+is( Text::VisualWidth::PP::trim("Mọi người",8), "Mọi ngườ", 'VI trim 2');
 
 ok( Text::VisualWidth::PP::width("Mọi người") == 9, 'VI combined width');
 is( Text::VisualWidth::PP::trim("Mọi người",2), "Mọ", 'VI combined trim');


### PR DESCRIPTION
Related to the issue #4

Fixed t/06_combined.t to run with perl < 5.12, managing the different behavior of \X in regex.
Now it does not use Unicode names in the string to avoid troubles.

Also I created a GitHub workflow.  Use it if you want.
